### PR TITLE
Add ability to override channel on send

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ Send a message to the queue, using the specified options, if any.  Your message
 must either be an instance of the Buffer object, or you must have overridden
 `QueueWorker#serializeMessage` to return a Buffer.
 
+You may use a different channel to send a message to a queue by passing in a `channel`
+key on the `sendOpts` object.
+
 #### QueueWorker#messageHandler(msg:Object):undefined
 **This MUST be implemented!**
 Handle messages coming in from RabbitMQ.  The `msg` object is the same

--- a/test/amqp-worker.spec.js
+++ b/test/amqp-worker.spec.js
@@ -330,6 +330,7 @@ test('listen, no handler', async (t) => {
   worker.queue = 'test-queue'
   try {
     await worker.listen()
+    await worker.messageHandler()
   } catch (err) {
     t.equal(err.message, 'You must implement this.messageHandler')
   }


### PR DESCRIPTION
Also, throw if messageHandler is not implemented

changes made:
---
- [x] throw if messageHandler not implemented
- [x] allow channel override on sendMessage
- [x] allow queue override on sendMessage
- [x] use messageHandler (whoops)

version:
---
- minor