### PR TITLE
Ensure consumer is bound to right context

### DIFF
--- a/amqp-worker.js
+++ b/amqp-worker.js
@@ -116,7 +116,7 @@ class QueueWorker {
 
     await this.getChannel()
     await this.channel.assertQueue(this.queue, assertOpts)
-    const consumer = await this.channel.consume(this.queue, this.messageHandler, consumeOpts)
+    const consumer = await this.channel.consume(this.queue, (msg) => this.messageHandler(msg), consumeOpts)
     this.listening = true
     return consumer
   }


### PR DESCRIPTION
AMQPLib doesn't invoke the consumer with the appropriate context so we need
to use an arrow function to keep the lexcial this binding of the outer scope

changes made:
---
- [x] use arrow function for lexical this

version:
---
- patch