### PR TITLE
updates for new repo location

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # amqp-worker
 
-[![Build Status](https://travis-ci.org/scriptoLLC/amqp-worker.svg?branch=master)](https://travis-ci.org/scriptoLLC/amqp-worker)
+[![Build Status](https://travis-ci.org/showrunner/amqp-worker.svg?branch=master)](https://travis-ci.org/showrunner/amqp-worker)
 
 A base worker class for connecting to and dealing with RabbitMQ.
 
@@ -14,13 +14,13 @@ This is mostly a convenience wrapper around [amqplib](http://www.squaremobius.ne
 - [RabbitMQ](https://www.rabbitmq.com/)
 
 ```
-npm install @scriptollc/amqp-worker
+npm install @showrunner/amqp-worker
 ```
 
 ## Usage
 
 ```js
-const QueueWorker = require('@scriptollc/amqp-worker')
+const QueueWorker = require('@showrunner/amqp-worker')
 
 class MyWorker extends QueueWorker {
   constructor () {
@@ -46,7 +46,7 @@ to manage this as well. Since this is an ES6 class however, prototyping
 requires the use of `Reflect`:
 
 ```js
-const QueueWorker = require('@scriptollc/amqp-worker')
+const QueueWorker = require('@showrunner/amqp-worker')
 
 function MyWorker () {
   Object.assign(this, Reflect.construct(QueueWorker, arguments, MyWorker))

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scriptollc/amqp-worker",
+  "name": "@showrunner/amqp-worker",
   "version": "1.3.2",
   "description": "Class for creating AMQP connections",
   "main": "amqp-worker.js",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/scriptoLLC/amqp-worker.git"
+    "url": "git+https://github.com/showrunner/amqp-worker.git"
   },
   "keywords": [
     "rabbitmq",
@@ -22,9 +22,9 @@
   "author": "Todd Kennedy <todd@selfassembled.org>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/scriptoLLC/amqp-worker/issues"
+    "url": "https://github.com/showrunner/amqp-worker/issues"
   },
-  "homepage": "https://github.com/scriptoLLC/amqp-worker#readme",
+  "homepage": "https://github.com/showrunner/amqp-worker#readme",
   "dependencies": {
     "amqplib": "^0.5.2"
   },


### PR DESCRIPTION
We use this in our rabbit-worker, moving it to the showrunner org.
Added the `.npmrc` file since this didn't have an existing `package-lock` file