### PR TITLE
Update amqplib dep and fix test credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-sudo: required
-services:
-  - rabbitmq
-node_js:
-  - "8"
-  - "9" 

--- a/amqp-worker.js
+++ b/amqp-worker.js
@@ -2,8 +2,8 @@ const amqp = require('amqplib')
 
 const rabbitMQHost = process.env.RABBIT_MQ_HOST || 'localhost'
 const rabbitMQPort = process.env.RABBIT_MQ_PORT || 5672
-const rabbitMQUser = process.env.RABBIT_MQ_USER || 'guest'
-const rabbitMQPass = process.env.RABBIT_MQ_PASS || 'guest'
+const rabbitMQUser = process.env.RABBIT_MQ_USER || 'showrunner'
+const rabbitMQPass = process.env.RABBIT_MQ_PASS || 'showrunner'
 
 class QueueWorker {
   constructor (host, port, opts) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/showrunner/amqp-worker#readme",
   "dependencies": {
-    "amqplib": "^0.5.2"
+    "amqplib": "^0.8.0"
   },
   "devDependencies": {
     "dependency-check": "^3.0.0",


### PR DESCRIPTION
**background:** This one-file repo is used by rabbit-worker and wraps the amqplib package.  It looks like it hasn't been updated in a long time and the tests weren't passing because we use a different username/password on our rabbitmq. 

Here's what I did:
* I updated the amqplib dependency to the newer one that I want to move  api to.
* I change the user/password and got tests to pass locally. 

There's a .travis.yml file in the repo but I've NEVER seen us have any travis-based testing... I'm not sure if I just broke some forgotten ci testing somewhere or what... but the tests ARE passing locally for me. 

After we merge this, I'll do a release and update rabbit-worker to use this version and also move the repo to node 16
